### PR TITLE
Filter unit test

### DIFF
--- a/context-app/src/components/Filter.js
+++ b/context-app/src/components/Filter.js
@@ -35,12 +35,12 @@ export default function Filter({
   }, [filterText])
 
   return (
-    <>
-      <span>{`${label}: `}</span>
+    <label>
       <input
         value={filterText}
         onChange={(element) => setFilterText(element.target.value)}
       />
-    </>
+      {`${label}: `}
+    </label>
   )
 }

--- a/context-app/src/components/Filter.test.js
+++ b/context-app/src/components/Filter.test.js
@@ -1,18 +1,74 @@
 import React from 'react' 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Filter from './Filter';
 
 describe('Filter', () => {
 
-  it('renders label', () => {
+  it('renders the label', () => {
 
     const {getByText} = render(<Filter 
       label="filter test"
       unfilteredList={[]}
       onChange={() => {}}
-    />);
+    />)
 
-    expect(getByText(/filterTest/i)).toBeInTheDocument()
+    expect(getByText(/filter test/i)).toBeInTheDocument()
 
+  })
+
+  it('filters by key-value', () => {
+
+    const mockCallBack = jest.fn()
+
+    const testList = [
+        {test_key: "Test User", shmeggle_key: "precious"}, 
+        {test_key: "Best User", shmeggle_key: "mine"}
+      ]
+
+    const testListFiltered = [
+      {test_key: "Best User", shmeggle_key: "mine"}
+    ]
+
+    const {queryByLabelText, getByLabelText} = render(<Filter
+      label="filter test"
+      unfilteredList={testList}
+      onChange={mockCallBack}
+    />)
+
+    expect(mockCallBack).toHaveBeenCalledWith(testList)
+
+    mockCallBack.mockClear()
+
+    fireEvent.change(getByLabelText(/filter test/i), {target: {value:"mine"}})
+
+    expect(mockCallBack).toHaveBeenCalledWith(testListFiltered)
+  })
+  
+  it('resets when provided an empty string', () => {
+
+    const mockCallBack = jest.fn()
+
+    const testList = [
+        {test_key: "Test User", shmeggle_key: "precious"}, 
+        {test_key: "Best User", shmeggle_key: "mine"}
+      ]
+
+    const testListFiltered = [
+      {test_key: "Best User", shmeggle_key: "mine"}
+    ]
+
+    const {queryByLabelText, getByLabelText} = render(<Filter
+      label="filter test"
+      unfilteredList={testList}
+      onChange={mockCallBack}
+    />)
+
+    fireEvent.change(getByLabelText(/filter test/i), {target: {value:"mine"}})
+    
+    mockCallBack.mockClear()
+
+    fireEvent.change(getByLabelText(/filter test/i), {target: {value:""}})
+
+    expect(mockCallBack).toHaveBeenCalledWith(testList)
   })
 })

--- a/context-app/src/components/Filter.test.js
+++ b/context-app/src/components/Filter.test.js
@@ -1,0 +1,18 @@
+import React from 'react' 
+import { render, screen } from '@testing-library/react';
+import Filter from './Filter';
+
+describe('Filter', () => {
+
+  it('renders label', () => {
+
+    const {getByText} = render(<Filter 
+      label="filter test"
+      unfilteredList={[]}
+      onChange={() => {}}
+    />);
+
+    expect(getByText(/filterTest/i)).toBeInTheDocument()
+
+  })
+})

--- a/context-app/src/components/Filter.test.js
+++ b/context-app/src/components/Filter.test.js
@@ -22,7 +22,8 @@ describe('Filter', () => {
 
     const testList = [
         {test_key: "Test User", shmeggle_key: "precious"}, 
-        {test_key: "Best User", shmeggle_key: "mine"}
+        {test_key: "Best User", shmeggle_key: "mine"},
+        {blast_key: "boom"}
       ]
 
     const testListFiltered = [
@@ -50,12 +51,9 @@ describe('Filter', () => {
 
     const testList = [
         {test_key: "Test User", shmeggle_key: "precious"}, 
-        {test_key: "Best User", shmeggle_key: "mine"}
+        {test_key: "Best User", shmeggle_key: "mine"},
+        {blast_key: "boom"}
       ]
-
-    const testListFiltered = [
-      {test_key: "Best User", shmeggle_key: "mine"}
-    ]
 
     const {queryByLabelText, getByLabelText} = render(<Filter
       label="filter test"
@@ -70,5 +68,28 @@ describe('Filter', () => {
     fireEvent.change(getByLabelText(/filter test/i), {target: {value:""}})
 
     expect(mockCallBack).toHaveBeenCalledWith(testList)
+  })
+
+  it('returns an empty array if there is no match', () => {
+
+    const mockCallBack = jest.fn()
+
+    const testList = [
+        {test_key: "Test User", shmeggle_key: "precious"}, 
+        {test_key: "Best User", shmeggle_key: "mine"},
+        {blast_key: "boom"}
+      ]
+
+    const {queryByLabelText, getByLabelText} = render(<Filter
+      label="filter test"
+      unfilteredList={testList}
+      onChange={mockCallBack}
+    />)
+
+    mockCallBack.mockClear()
+
+    fireEvent.change(getByLabelText(/filter test/i), {target: {value:"samoflange"}})
+
+    expect(mockCallBack).toHaveBeenCalledWith([])
   })
 })


### PR DESCRIPTION
We add a test of the filter component. The component is abstracted enough that it can take any array that contains objects that are key-value pairs. It isn't very opinionated beyond that, and doesn't even require that the objects are shaped in a consistent manner.