### PR TITLE
Client actions test

### DIFF
--- a/context-app/package.json
+++ b/context-app/package.json
@@ -27,6 +27,7 @@
     "react-redux": "^7.2.2",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
+    "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.4.1",
     "web-vitals": "^2.1.4"
   },

--- a/context-app/src/actions/clientActions.test.js
+++ b/context-app/src/actions/clientActions.test.js
@@ -1,0 +1,41 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
+import {
+  loadClientList
+} from './clientActions'
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const store = mockStore({
+  client: {
+    clientList: []
+  }
+})
+const mock = new MockAdapter(axios);
+
+const testResponse = "some_response"
+
+describe('Testing loadClientList', () => {
+  beforeEach(() => {
+    store.clearActions()
+    mock.reset()
+    window.alert = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    window.alert.mockClear();
+  })
+
+  it('should handle success', async () => {
+    // we can use environment variables to set the host
+    // depending on the context to differenciate between
+    // dev and prod in a mature application
+    mock.onGet("http://localhost:3001/client_list").reply(200, testResponse)
+
+    await store.dispatch(loadClientList())
+    expect(store.getActions()).toEqual("your mom")
+  })
+})

--- a/context-app/src/duckTests/clientActionsDuck.test.js
+++ b/context-app/src/duckTests/clientActionsDuck.test.js
@@ -2,14 +2,17 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import MockAdapter from 'axios-mock-adapter'
 import axios from 'axios'
+
 import {
   loadClientList
-} from './clientActions'
+} from '../actions/clientActions'
+
+import combinedReducer from '../reducers/combinedReducer'
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 const store = mockStore({
-  client: {
+  clients: {
     clientList: []
   }
 })
@@ -22,6 +25,7 @@ describe('Testing loadClientList', () => {
     store.clearActions()
     mock.reset()
     window.alert = jest.fn()
+
   })
 
   afterEach(() => {
@@ -36,6 +40,11 @@ describe('Testing loadClientList', () => {
     mock.onGet("http://localhost:3001/client_list").reply(200, testResponse)
 
     await store.dispatch(loadClientList())
-    expect(store.getActions()).toEqual("your mom")
+
+    const finalState = store.getActions().reduce((acc, item) => {
+      return combinedReducer(acc, item)
+    }, store.getState())
+
+    expect(finalState).toEqual({clients: {clientList: testResponse}})
   })
 })

--- a/context-app/src/duckTests/clientActionsDuck.test.js
+++ b/context-app/src/duckTests/clientActionsDuck.test.js
@@ -1,5 +1,3 @@
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import MockAdapter from 'axios-mock-adapter'
 import axios from 'axios'
 
@@ -7,11 +5,22 @@ import {
   loadClientList
 } from '../actions/clientActions'
 
-import combinedReducer from '../reducers/combinedReducer'
+import getFinalStateFromAction from './getFinalStateFromAction'
+import setupMockStore from './setupMockStore'
 
-const middlewares = [thunk];
-const mockStore = configureMockStore(middlewares);
-const store = mockStore({
+// The idea behind this duck test is to try to avoid the trap of 
+// testing the implementation. Lots of the stuff here is boilerplate
+// that really should be abstracted away. We are using strong conventions
+// in the setup of the asychronous behavior, so the tests should also 
+// have those conventions enshrined using abstraction.
+//
+// The main thing is that we want to know that when the action is called,
+// it produces the desired result in the redux store. If that is working,
+// then all the components that depend upon that behavior will also work.
+// Inspecting the actual behavior of the API is a topic for an integration
+// test, and outside the scope of this exercise.
+
+const store = setupMockStore({
   clients: {
     clientList: []
   }
@@ -39,12 +48,29 @@ describe('Testing loadClientList', () => {
     // dev and prod in a mature application
     mock.onGet("http://localhost:3001/client_list").reply(200, testResponse)
 
-    await store.dispatch(loadClientList())
-
-    const finalState = store.getActions().reduce((acc, item) => {
-      return combinedReducer(acc, item)
-    }, store.getState())
+    const finalState = await getFinalStateFromAction(store, loadClientList)
 
     expect(finalState).toEqual({clients: {clientList: testResponse}})
+  })
+
+  it('should handle failure', async () => {
+
+    mock.onGet("http://localhost:3001/client_list").reply(400)
+
+    const finalState = await getFinalStateFromAction(store, loadClientList)
+
+    // no change, because of error
+    //
+    // Note that we could have persisted the error state, in the event that we
+    // are reasonably confident that the error state would be tied to a specific
+    // bit of UX requiring that the error message be displayed in-line with a 
+    // button or something. In this simplistic example, that seems a bit overboard.
+    expect(finalState).toEqual(store.getState())
+
+    const errorMessage = `The list of clients could not be fetched. \n`
+      +`Reload the page to try again. If you continue to experience this error, `
+      +`contact the administrator at seminative@gmail.com`
+
+    expect(window.alert.mock.calls[0][0].replace(/\s/g, '')).toEqual(errorMessage.replace(/\s/g, '')) 
   })
 })

--- a/context-app/src/duckTests/getFinalStateFromAction.js
+++ b/context-app/src/duckTests/getFinalStateFromAction.js
@@ -1,0 +1,10 @@
+import combinedReducer from '../reducers/combinedReducer'
+
+export default async function getFinalStateFromAction(store, action) {
+
+  await store.dispatch(action())
+  
+  return store.getActions().reduce((acc, item) => {
+      return combinedReducer(acc, item)
+    }, store.getState())
+}

--- a/context-app/src/duckTests/setupMockStore.js
+++ b/context-app/src/duckTests/setupMockStore.js
@@ -1,0 +1,10 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+export default function setupMockStore(initialStore) { 
+  const middlewares = [thunk];
+  const mockStore = configureMockStore(middlewares);
+  const store = mockStore(initialStore)
+
+  return store
+}

--- a/context-app/yarn.lock
+++ b/context-app/yarn.lock
@@ -5953,6 +5953,11 @@ lodash.flow@^3.5.0:
   resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
   integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -7474,6 +7479,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux-mock-store@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-thunk@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
We add a "duck" test of the action and reducer.

Basically, we want to steer clear of testing for the implementation, and instead observe the final result. If the implementation is not conformant, it will fail, but we don't need to step through all of that for every action. 